### PR TITLE
Fixing issue with socketio forcing secure by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.idea
 yarn.lock
 /.vscode
+*.swp
+*.swo

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -5,7 +5,7 @@ import ChatBubble from "../ChatBubble/";
 import ThemeProvider from "../ThemeProvider/index"; // socket io doesn't properly import from webpack?
 /* import io from "socket.io-client";*/ const io = window.io || {};
 
-const socketPath = `http://${process.env.REMOTE_HOST || 'localhost'}:8000`;
+const socketPath = `http://${process.env.REMOTE_HOST || 'localhost'}:${process.env.REMOTE_PORT || '8000'}`;
 
 class App extends Component {
   state = {
@@ -18,6 +18,7 @@ class App extends Component {
   componentDidMount() {
     window.jam = this;
     this.socket = io.connect(socketPath, {
+      secure: false,
       reconnectionAttempts: 10,
       query: "type=client"
     });

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
-    new webpack.EnvironmentPlugin(['NODE_ENV', 'PORT', 'REMOTE_HOST'])
+    new webpack.EnvironmentPlugin(['NODE_ENV', 'PORT', 'REMOTE_HOST','REMOTE_PORT'])
   ].concat(
     ENV === 'production'
       ? [
@@ -114,13 +114,14 @@ module.exports = {
 
   stats: { colors: true },
 
+  // I dont think any of these are necessary
   node: {
     global: true,
-    process: false,
-    Buffer: false,
-    __filename: false,
-    __dirname: false,
-    setImmediate: false,
+    // process: false,
+    // Buffer: false,
+    // __filename: false,
+    // __dirname: false,
+    // setImmediate: false,
   },
 
   devtool: ENV === 'production' ? 'source-map' : 'cheap-module-eval-source-map',
@@ -131,7 +132,7 @@ module.exports = {
 		publicPath: '/',
 		contentBase: './build',
 		historyApiFallback: true,
-		open: true,
+		open: true, // This annoys the hell out of me
 		proxy: {
 			// OPTIONAL: proxy configuration:
 			// '/optional-prefix/**': { // path pattern to rewrite


### PR DESCRIPTION
I am not sure why, but since we havent added SSL support in the daemon yet (could be good for 0.2) this version of the client lib forces https I think? which gave me a `SSL_PROTOCOL_ERROR` when trying to connect to the daemon.... which in turn _I think_ caused the `POST` request. 

Its working for me now.

Also added vim gitignores